### PR TITLE
Updating fig to docker compose

### DIFF
--- a/setup_as_dev.sh
+++ b/setup_as_dev.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -e "s/HOST_USERNAME/`whoami`/" dev.yml > fig.yml
+sed -e "s/HOST_USERNAME/`whoami`/" dev.yml > docker-compose.yml

--- a/setup_as_imp.sh
+++ b/setup_as_imp.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -e "s/HOST_USERNAME/`whoami`/" imp.yml > fig.yml
+sed -e "s/HOST_USERNAME/`whoami`/" imp.yml > docker-compose.yml


### PR DESCRIPTION
Hi,

I just finished installing MOTECH using docker. [Fig has been replaced by Docker Compose](http://www.fig.sh) and is depreciated. I'll send the updated install instructions in a separate email.

Sincerely,
Craig

